### PR TITLE
Use stock debian igmpproxy instead of building.

### DIFF
--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -1,6 +1,6 @@
 # Packages included in ARM64 images by default
 packages = [
-  "grub-efi-arm64",
+  "grub-efi-arm64", "igmpproxy",
 ]
 bootloaders = "grub-efi"
 


### PR DESCRIPTION
Needs corresponding pull in nexus-build
