### PR TITLE
Modify default UART console to ttyS0 for J7200 platform

### DIFF
--- a/scripts/package-build/linux-kernel/platform/ti-evm/bookworm-am64xx-evm/patches/kernel/0005-modify-default-uart-console.patch
+++ b/scripts/package-build/linux-kernel/platform/ti-evm/bookworm-am64xx-evm/patches/kernel/0005-modify-default-uart-console.patch
@@ -15,8 +15,8 @@ index ee36cd011661..4a35297006d0 100644
 -		serial1 = &main_uart1;
 -		serial2 = &main_uart0;
 +		serial0 = &main_uart0;
-+		serial1 = &mcu_uart0;
-+		serial2 = &main_uart1;
++		serial1 = &main_uart1;
++		serial2 = &mcu_uart0;
  		serial3 = &main_uart3;
  		i2c0 = &main_i2c0;
  		i2c1 = &main_i2c1;

--- a/scripts/package-build/linux-kernel/platform/ti-evm/bookworm-j7200-evm/patches/kernel/0005-modify-j7200-default-uart-console.patch
+++ b/scripts/package-build/linux-kernel/platform/ti-evm/bookworm-j7200-evm/patches/kernel/0005-modify-j7200-default-uart-console.patch
@@ -1,0 +1,25 @@
+diff --git a/arch/arm64/boot/dts/ti/k3-j7200-common-proc-board.dts b/arch/arm64/boot/dts/ti/k3-j7200-common-proc-board.dts
+index 9b122117ef72..89165936939a 100644
+--- a/arch/arm64/boot/dts/ti/k3-j7200-common-proc-board.dts
++++ b/arch/arm64/boot/dts/ti/k3-j7200-common-proc-board.dts
+@@ -17,9 +17,9 @@ / {
+ 	model = "Texas Instruments J7200 EVM";
+ 
+ 	aliases {
+-		serial0 = &wkup_uart0;
++		serial0 = &main_uart0;
+ 		serial1 = &mcu_uart0;
+-		serial2 = &main_uart0;
++		serial2 = &wkup_uart0;
+ 		serial3 = &main_uart1;
+ 		serial5 = &main_uart3;
+ 		mmc0 = &main_sdhci0;
+@@ -27,7 +27,7 @@ aliases {
+ 	};
+ 
+ 	chosen {
+-		stdout-path = "serial2:115200n8";
++		stdout-path = "serial0:115200n8";
+ 	};
+ 
+ 	evm_12v0: fixedregulator-evm12v0 {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Modify default UART console from ttyS2 to ttyS0 on J7200 platform

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/psleng/ti-bdebstrap/pull/6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
