### PR TITLE
Update NXP wifi to lf-6.12.20_2.0.0

### DIFF
--- a/scripts/package-build/linux-kernel/build_iGOS_drivers/build_iGOS_drivers
+++ b/scripts/package-build/linux-kernel/build_iGOS_drivers/build_iGOS_drivers
@@ -7,8 +7,10 @@ echo === $0 BEGIN in $PWD
 # Initialize repository URL variable
 : ${REPO_URL:="https://github.com/psleng"}
 : ${ROOTDIR:=$(dirname $(sudo git rev-parse --show-toplevel))}
+
 #BRANCH=lf-6.6.3_1.0.0
-BRANCH=lf-6.6.52_2.2.0
+#BRANCH=lf-6.6.52_2.2.0
+BRANCH=lf-6.12.20_2.0.0
 
 echo "Build/Install NXP 88Q9098/88W9098 branch $BRANCH"
 

--- a/scripts/package-build/linux-kernel/build_iGOS_drivers/imx-firmware.lf-6.12.20_2.0.0.patch
+++ b/scripts/package-build/linux-kernel/build_iGOS_drivers/imx-firmware.lf-6.12.20_2.0.0.patch
@@ -1,0 +1,23 @@
+diff --git a/nxp/wifi_mod_para.conf b/nxp/wifi_mod_para.conf
+index 9532439..6d67b39 100644
+--- a/nxp/wifi_mod_para.conf
++++ b/nxp/wifi_mod_para.conf
+@@ -88,12 +88,18 @@ PCIE9098_0 = {
+ 	max_vir_bss=1
+ 	cal_data_cfg=none
+ 	fw_name=nxp/pcieuart9098_combo_v1.bin
++	# PSL: increase connections from the default 8 (client and AP).
++	uap_max_sta = 64
++	max_sta_conn = 64
+ }
+ 
+ PCIE9098_1 = {
+ 	max_vir_bss=1
+ 	cal_data_cfg=none
+ 	fw_name=nxp/pcieuart9098_combo_v1.bin
++	# PSL: increase connections from the default 8 (client and AP).
++	uap_max_sta = 64
++	max_sta_conn = 64
+ }
+ 
+ PCIEAW693_0 = {

--- a/scripts/package-build/linux-kernel/build_iGOS_drivers/mwifiex.lf-6.12.20_2.0.0.patch
+++ b/scripts/package-build/linux-kernel/build_iGOS_drivers/mwifiex.lf-6.12.20_2.0.0.patch
@@ -1,0 +1,28 @@
+diff --git a/mlinux/moal_uap_cfg80211.c b/mlinux/moal_uap_cfg80211.c
+index ce7cbd3..427044a 100644
+--- a/mlinux/moal_uap_cfg80211.c
++++ b/mlinux/moal_uap_cfg80211.c
+@@ -4334,9 +4334,22 @@ int woal_uap_cfg80211_dump_station(struct wiphy *wiphy, struct net_device *dev,
+ 			ETH_ALEN);
+ 	PRINTM(MIOCTL, "Dump station: " MACSTR " RSSI=%d\n", MAC2STR(mac),
+ 	       (int)info->param.sta_list.info[idx].rssi);
++//printk(KERN_ALERT "%s: " MACSTR " rx=%d tx=%d\n", __func__, MAC2STR(mac), info->param.sta_list.info[idx].stats.rx_bytes, info->param.sta_list.info[idx].stats.tx_bytes); // TODO HACK RPH
+ #if CFG80211_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
++	//sinfo->filled = BIT(NL80211_STA_INFO_INACTIVE_TIME) |
++	//		BIT(NL80211_STA_INFO_SIGNAL);
+ 	sinfo->filled = BIT(NL80211_STA_INFO_INACTIVE_TIME) |
+-			BIT(NL80211_STA_INFO_SIGNAL);
++	                BIT(NL80211_STA_INFO_RX_BYTES) |
++	                BIT(NL80211_STA_INFO_TX_BYTES) |
++	                BIT(NL80211_STA_INFO_RX_PACKETS) |
++	                BIT(NL80211_STA_INFO_TX_PACKETS) |
++	                BIT(NL80211_STA_INFO_SIGNAL_AVG);
++	// VyOS expects all of these to be in place
++	sinfo->rx_bytes   = info->param.sta_list.info[idx].stats.rx_bytes;
++	sinfo->tx_bytes   = info->param.sta_list.info[idx].stats.tx_bytes;
++	sinfo->rx_packets = info->param.sta_list.info[idx].stats.rx_packets;
++	sinfo->tx_packets = info->param.sta_list.info[idx].stats.tx_packets;
++	sinfo->signal_avg = info->param.sta_list.info[idx].rssi;
+ #else
+ 	sinfo->filled = STATION_INFO_INACTIVE_TIME | STATION_INFO_SIGNAL;
+ #endif


### PR DESCRIPTION
Merge mwifiex and imx-firmware repos from NXP upstream and regenerate patches.

NOTE: Do not worry about dmesg messages like this:

    [  124.603998] fw doesn't support 11ac
    [  124.608208] fw doesn't support 11ax

This refers to phy1 only.  Those modes are supported by phy0 on the W9098.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
