### PR TITLE
Backport Openssh 10.0p2 to bookworm for vyos build

### DIFF
--- a/data/live-build-config/archives/bookworm-backports.pref.chroot
+++ b/data/live-build-config/archives/bookworm-backports.pref.chroot
@@ -6,6 +6,18 @@ Package: suricata libhtp2
 Pin: release n=bookworm-backports
 Pin-Priority: 600
 
+Package: openssh-client
+Pin: release n=bookworm-backports
+Pin-Priority: 600
+
+Package: openssh-server
+Pin: release n=bookworm-backports
+Pin-Priority: 600
+
+Package: openssh-sftp-server
+Pin: release n=bookworm-backports
+Pin-Priority: 600
+
 Package: *
 Pin: release n=bookworm-backports
 Pin-Priority: -100


### PR DESCRIPTION
Shu Zhou found this neat way to add Bookworm backported packages to the build.  This particular change was to include Openssh version 10.0p2 which addresses error syslogs on TSS2 tpm-backed hostkey support using ssh-tpm-agent, and to fix support for native various SSH clients that request validating ALL sshd hostkeys (including TSS2 tpm backed) sent in the SSHD's hostkey response to the client.  This latter issue caused the SSHD server to exit on error an close the connection.  After this upgrade to 10.0p2, the workarounds for suppressing the hostkey list validation from the client will no longer be needed 
