### PR TITLE
Prevent vpp double-building attempts.

### DIFF
--- a/scripts/package-build/vpp/package.toml
+++ b/scripts/package-build/vpp/package.toml
@@ -18,6 +18,7 @@ rsync -av ../vyos-vpp-patches/patches/vpp/ ../patches/vpp/
 """
 
 build_cmd = """
+test -f ../vpp_*.deb && { echo I: vpp already built; exit 0; } # PSL
 # Patches for vpp should applied here
 for patch in ../patches/vpp/*.patch; do
     echo "I: build_cmd applying patch $patch..."


### PR DESCRIPTION
During the kernel build, it calls build-accel-ppp-ng.sh which builds vpp.
Later on during the full filesystem build, package build tries to
build it yet again.  This fails with nasty obscure fatal "git am"
errors because it tries to apply the patches which were already applied.

Fortunately the build continues, which is why it hasn't caused problems,
but it leads to this confusing error in the buildlog output:

 fatal: previous rebase directory .git/rebase-apply still exists but mbox given.

This is arguably a fundamental error in the VyOS build system:
build.py is too dumb to know something has already been built,
and they depend on the build continuing even if a specific
build.py call fails, but for now specifically blocking the vpp
rebuild via package.toml seems to be the cleanest fix.

vpp appears to be the only package suffering from this specific problem.
