### PR TITLE
Revert arm64 console back to ttyS0 from ttyAMA0

### DIFF
--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -5,4 +5,6 @@ packages = [
 ]
 bootloaders = "grub-efi"
 squashfs_compression_type = "xz -b 256k -always-use-fragments -no-recovery"
-serial_interface = "ttyAMA0,115200"
+# PERLE - ttyAMA0 not applicable for TI arm64 processors
+# serial_interface = "ttyAMA0,115200"
+serial_interface = "ttyS0,115200"


### PR DESCRIPTION
The VyOS developers changed the console from ttyS0 to ttyAMA0 likely due to support for running under an ARM64 VM.  Some ARM64 processors may also use the ttyAMA0 for built in high performance uart, but for our TI based ARM64 processors, we need ttyS0 instead.  This is a minimal revert back to ttyS0 by setting the default console, leaving in most of the python/grub rendering logic as part of T8120 code changes 